### PR TITLE
update latest ref docs

### DIFF
--- a/reference/sketch_launch_promise_thread.rst
+++ b/reference/sketch_launch_promise_thread.rst
@@ -28,7 +28,7 @@ Examples
 
 
     def load_data():
-        return py5.load_json('http://py5.ixora.io/secret_message.json')
+        return py5.load_json('http://py5.ixora.io/files/secret_message.json')
 
 
     def draw():
@@ -76,5 +76,5 @@ Parameters
 * **name**: `str = None` - name of thread to be created
 
 
-Updated on March 22, 2022 21:53:01pm UTC
+Updated on August 24, 2022 22:21:43pm UTC
 

--- a/reference/sketch_size.rst
+++ b/reference/sketch_size.rst
@@ -85,6 +85,27 @@ Examples
 
 .. raw:: html
 
+    <div class="example-row"><div class="example-cell-image">
+
+.. raw:: html
+
+    </div><div class="example-cell-code">
+
+.. code:: python
+    :number-lines:
+
+    def setup():
+        py5.size(200, 400, py5.PDF, 'output.pdf')
+        py5.background(153)
+        py5.line(0, 0, py5.width, py5.height)
+        py5.exit_sketch()  # needed to save and close the output properly
+
+.. raw:: html
+
+    </div></div>
+
+.. raw:: html
+
     </div>
 
 Description
@@ -112,6 +133,8 @@ The ``renderer`` parameter selects which rendering engine to use. For example, i
 * ``PDF``: The ``PDF`` renderer draws 2D graphics directly to an Acrobat PDF file. This produces excellent results when you need vector shapes for high-resolution output or printing.
 * ``SVG``: The ``SVG`` renderer draws 2D graphics directly to an SVG file. This is great for importing into other vector programs or using for digital fabrication.
 
+When using the ``PDF`` and ``SVG`` renderers with the ``size()`` method, you must use the ``path`` parameter to specify the file to write the output to. No window will open while the Sketch is running. You must also call :doc:`sketch_exit_sketch` to exit the Sketch and write the completed output to the file. Without this call, the Sketch will not exit and the output file will be empty. If you would like to draw 3D objects to a PDF or SVG file, use the ``P3D`` renderer and the strategy described in :doc:`sketch_begin_raw`.
+
 Underlying Processing method: `size <https://processing.org/reference/size_.html>`_
 
 Syntax
@@ -132,5 +155,5 @@ Parameters
 * **width**: `int` - width of the display window in units of pixels
 
 
-Updated on November 12, 2021 11:30:58am UTC
+Updated on August 24, 2022 22:21:43pm UTC
 


### PR DESCRIPTION
update @villares 's recent PR and another small change

@villares , every time you make a PR to the reference docs, you can if you like make a second PR to py5book. You'd need to clone the py5book repo and then in the py5generator repo, run this command:

```bash
make generate_py5_docs py5_website_dir=../py5book py5_api_lang=api_en
```

That will generate the reference docs and write then to the ../py5book directory (where mine is located, you might organize your repos differently)

Then you can make the py5book and check it by clicking on the link provided to you when that build completes.
