### PR TITLE
Bugfix/no ref/correct constrain documentation

### DIFF
--- a/reference/sketch_constrain.md
+++ b/reference/sketch_constrain.md
@@ -1,6 +1,6 @@
 # constrain()
 
-Constrains a value to not exceed a maximum and minimum value.
+Constrains a value between a minimum and maximum value.
 
 ## Examples
 
@@ -23,7 +23,7 @@ def draw():
 
 ## Description
 
-Constrains a value to not exceed a maximum and minimum value.
+Restrict the input value to a specified range defined by a minimum and a maximum limit.
 
 ## Signatures
 

--- a/reference/sketch_constrain.md
+++ b/reference/sketch_constrain.md
@@ -30,8 +30,8 @@ Constrains a value to not exceed a maximum and minimum value.
 ```python
 constrain(
     amt: Union[float, npt.NDArray],  # the value to constrain
-    low: Union[float, npt.NDArray],  # maximum limit
-    high: Union[float, npt.NDArray],  # minimum limit
+    low: Union[float, npt.NDArray],  # minimum limit
+    high: Union[float, npt.NDArray],  # maximum limit
 ) -> Union[float, npt.NDArray]
 ```
 


### PR DESCRIPTION
I corrected the mix between 'maximum' and 'minimum' in the explanation of the function signature.

I also made another commit to make the description of what the function does clearer, I find the sentence "to not exceed ... a minimum value" a bit weird.