### PR TITLE
Adding an example to the first page of the Jupyter Notebook tutorial

### DIFF
--- a/tutorials/jupyter.ipynb
+++ b/tutorials/jupyter.ipynb
@@ -31,9 +31,7 @@
    "source": [
     "### Using the standard Python 3 (ipykernel) kernel\n",
     "\n",
-    "A minimal interactive example might look like this. As you evaluate the cell below a window with your running sketch should open, and moving the mouse over it should produce colored square trails that change color when you click the mouse button.\n",
-    "\n",
-    "![](../images/main/index_example.gif)"
+    "A minimal interactive example might look like this. As you evaluate the cell below a window with your running sketch should open, and moving the mouse over it should produce colored square trails that change color when you click the mouse button."
    ]
   },
   {

--- a/tutorials/jupyter.ipynb
+++ b/tutorials/jupyter.ipynb
@@ -13,13 +13,94 @@
     "\n",
     "Built into py5 are many features to make it compatible with Jupyter Notebooks. This empowers py5 to benefit from Jupyter's strengths. This section provides some tutorials that highlight py5's Jupyter-related features and how to make best use of them.\n",
     "\n",
-    "It is recommended that you install both of py5's Jupyter kernels. Instructions for how to do so are found at the bottom of the [py5 install page](/content/install)."
+    "It is recommended that you install both of py5's Jupyter kernels (py5 and py5bot). Instructions for how to do so are found at the bottom of the [py5 install page](/content/install).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7abffa89-4e6b-44c3-8e85-a73fe1338f40",
+   "metadata": {},
+   "source": [
+    "## Getting Started"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "388b20bd-073e-49ab-81d4-f37a77512b2b",
+   "metadata": {},
+   "source": [
+    "### Using the standard Python 3 (ipykernel) kernel\n",
+    "\n",
+    "A minimal interactive example might look like this. As you evaluate the cell below a window with your running sketch should open, and moving the mouse over it should produce colored square trails that change color when you click the mouse button.\n",
+    "\n",
+    "![](../images/main/index_example.gif)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "c8ffb936-88be-4d87-aee7-abf50666e232",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import py5\n",
+    "\n",
+    "def setup():\n",
+    "    py5.size(400, 400)\n",
+    "    py5.rect_mode(py5.CENTER)\n",
+    "\n",
+    "\n",
+    "def draw():\n",
+    "    py5.square(py5.mouse_x, py5.mouse_y, 10)\n",
+    "\n",
+    "\n",
+    "def mouse_clicked():\n",
+    "    py5.fill(py5.random_int(255), py5.random_int(255), py5.random_int(255))\n",
+    "\n",
+    "\n",
+    "py5.run_sketch()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7e44453d-f543-42a5-a470-f82fce777de9",
+   "metadata": {},
+   "source": [
+    "> It should look something like this GIF animation:<br>\n",
+    "> ![](../images/main/index_example.gif)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1bd4b8c4-d395-40a4-9073-f453558a84e3",
+   "metadata": {},
+   "source": [
+    "### Using the py5 kernel\n",
+    "\n",
+    "Having installed the py5 kernel, you can write code very similar to py5's imported mode, but adding `run_sketch()` at the end.\n",
+    "\n",
+    "```python\n",
+    "def setup():\n",
+    "    size(400, 400)\n",
+    "    rect_mode(CENTER)\n",
+    "\n",
+    "\n",
+    "def draw():\n",
+    "    square(mouse_x, mouse_y, 10)\n",
+    "\n",
+    "\n",
+    "def mouse_clicked():\n",
+    "    fill(random_int(255), random_int(255), random_int(255))\n",
+    "\n",
+    "\n",
+    "run_sketch()\n",
+    "```"
    ]
   }
  ],
  "metadata": {
   "jupytext": {
-   "formats": "ipynb,md:myst"
+   "formats": "ipynb,md"
   },
   "kernelspec": {
    "display_name": "Python 3 (ipykernel)",
@@ -36,7 +117,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.15"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,

--- a/tutorials/jupyter.md
+++ b/tutorials/jupyter.md
@@ -32,8 +32,6 @@ It is recommended that you install both of py5's Jupyter kernels (py5 and py5bot
 
 A minimal interactive example might look like this. As you evaluate the cell below a window with your running sketch should open, and moving the mouse over it should produce colored square trails that change color when you click the mouse button.
 
-![](../images/main/index_example.gif)
-
 ```python
 import py5
 

--- a/tutorials/jupyter.md
+++ b/tutorials/jupyter.md
@@ -1,15 +1,16 @@
 ---
-jupytext:
-  formats: ipynb,md:myst
-  text_representation:
-    extension: .md
-    format_name: myst
-    format_version: 0.13
-    jupytext_version: 1.14.4
-kernelspec:
-  display_name: Python 3 (ipykernel)
-  language: python
-  name: python3
+jupyter:
+  jupytext:
+    formats: ipynb,md
+    text_representation:
+      extension: .md
+      format_name: markdown
+      format_version: '1.3'
+      jupytext_version: 1.16.4
+  kernelspec:
+    display_name: Python 3 (ipykernel)
+    language: python
+    name: python3
 ---
 
 # Using Jupyter Notebooks
@@ -20,4 +21,60 @@ Jupyter plays a large role in the Python community and is supported by many orga
 
 Built into py5 are many features to make it compatible with Jupyter Notebooks. This empowers py5 to benefit from Jupyter's strengths. This section provides some tutorials that highlight py5's Jupyter-related features and how to make best use of them.
 
-It is recommended that you install both of py5's Jupyter kernels. Instructions for how to do so are found at the bottom of the [py5 install page](/content/install).
+It is recommended that you install both of py5's Jupyter kernels (py5 and py5bot). Instructions for how to do so are found at the bottom of the [py5 install page](/content/install).
+
+
+
+## Getting Started
+
+
+### Using the standard Python 3 (ipykernel) kernel
+
+A minimal interactive example might look like this. As you evaluate the cell below a window with your running sketch should open, and moving the mouse over it should produce colored square trails that change color when you click the mouse button.
+
+![](../images/main/index_example.gif)
+
+```python
+import py5
+
+def setup():
+    py5.size(400, 400)
+    py5.rect_mode(py5.CENTER)
+
+
+def draw():
+    py5.square(py5.mouse_x, py5.mouse_y, 10)
+
+
+def mouse_clicked():
+    py5.fill(py5.random_int(255), py5.random_int(255), py5.random_int(255))
+
+
+py5.run_sketch()
+```
+
+> It should look something like this GIF animation:<br>
+> ![](../images/main/index_example.gif)
+
+<!-- #region -->
+### Using the py5 kernel
+
+Having installed the py5 kernel, you can write code very similar to py5's imported mode, but adding `run_sketch()` at the end.
+
+```python
+def setup():
+    size(400, 400)
+    rect_mode(CENTER)
+
+
+def draw():
+    square(mouse_x, mouse_y, 10)
+
+
+def mouse_clicked():
+    fill(random_int(255), random_int(255), random_int(255))
+
+
+run_sketch()
+```
+<!-- #endregion -->


### PR DESCRIPTION
Let's see how this goes...
- I kept the "plain Python" kernel for this page/document and mentioned the py5 kernel style in markdown
- Another option would be to have a second page with the py5 kernel, but I feel it would be too much trouble for little gain. Also, I actually prefer having both examples on the same page.
- I have tried to use the code and GIF-file we had from the homepage example.

Previous discussion: https://github.com/py5coding/py5generator/discussions/491