### PR TITLE
Add the shader source code to the shader() example

### DIFF
--- a/reference/sketch_shader.md
+++ b/reference/sketch_shader.md
@@ -23,6 +23,50 @@ def draw():
     py5.shader(edges)
     py5.image(img, 0, 0)
 ```
+From  the `data` folder, the sketch will load the `edges.glsl` file below.
+
+```glsl
+#ifdef GL_ES
+precision mediump float;
+precision mediump int;
+#endif
+
+#define PROCESSING_TEXTURE_SHADER
+
+uniform sampler2D texture;
+uniform vec2 texOffset;
+
+varying vec4 vertColor;
+varying vec4 vertTexCoord;
+
+void main(void) {
+  // Grouping texcoord variables in order to make it work in the GMA 950. See post #13
+  // in this thread:
+  // http://www.idevgames.com/forums/thread-3467.html
+  vec2 tc0 = vertTexCoord.st + vec2(-texOffset.s, -texOffset.t);
+  vec2 tc1 = vertTexCoord.st + vec2(         0.0, -texOffset.t);
+  vec2 tc2 = vertTexCoord.st + vec2(+texOffset.s, -texOffset.t);
+  vec2 tc3 = vertTexCoord.st + vec2(-texOffset.s,          0.0);
+  vec2 tc4 = vertTexCoord.st + vec2(         0.0,          0.0);
+  vec2 tc5 = vertTexCoord.st + vec2(+texOffset.s,          0.0);
+  vec2 tc6 = vertTexCoord.st + vec2(-texOffset.s, +texOffset.t);
+  vec2 tc7 = vertTexCoord.st + vec2(         0.0, +texOffset.t);
+  vec2 tc8 = vertTexCoord.st + vec2(+texOffset.s, +texOffset.t);
+  
+  vec4 col0 = texture2D(texture, tc0);
+  vec4 col1 = texture2D(texture, tc1);
+  vec4 col2 = texture2D(texture, tc2);
+  vec4 col3 = texture2D(texture, tc3);
+  vec4 col4 = texture2D(texture, tc4);
+  vec4 col5 = texture2D(texture, tc5);
+  vec4 col6 = texture2D(texture, tc6);
+  vec4 col7 = texture2D(texture, tc7);
+  vec4 col8 = texture2D(texture, tc8);
+
+  vec4 sum = 8.0 * col4 - (col0 + col1 + col2 + col3 + col5 + col6 + col7 + col8); 
+  gl_FragColor = vec4(sum.rgb, 1.0) * vertColor;
+}
+```
 
 </div></div>
 


### PR DESCRIPTION
Dear @hx2A, 

I should have opened an issue... I know this might not be the correct way of fixing this, but I'll open the PR anyway as a way of not forgetting about it and losing the code I retrieved from the Processing examples, which is used on this documentation item (while in the middle of doing something else).

Feel free to close  this and/or to instruct me on how to do it properly, and I'll try at some other time :smile: 
... we should probably be discussing this in an issue, sorry!