### PR TITLE
Adding a note about the related `get_pixels()` methods on the `copy()` documentation pages

### DIFF
--- a/reference/py5graphics_copy.md
+++ b/reference/py5graphics_copy.md
@@ -10,6 +10,8 @@ This function ignores [](py5graphics_image_mode).
 
 This method is the same as [](sketch_copy) but linked to a `Py5Graphics` object. To see example code for how it can be used, see [](sketch_copy).
 
+If you want to create a new image with the contents of a rectangular region of a `Py5Graphics` object, check out the [`.get_pixels(x, y, w, h)`](py5graphics_get_pixels) method, where x, y, w, h, are the position and dimensions of the area to be copied. It will return a `Py5Image object`.
+
 Underlying Processing method: PGraphics.copy
 
 ## Signatures

--- a/reference/py5image_copy.md
+++ b/reference/py5image_copy.md
@@ -34,6 +34,8 @@ Copies a region of pixels from one image into another. If the source and destina
 
 This function ignores [](sketch_image_mode).
 
+If you want to create a new image with the contents of a rectangular region of a `Py5Image` object, check out the [`.get_pixels(x, y, w, h)`](py5image_get_pixels) method, where x, y, w, h, are the position and dimensions of the area to be copied. It will return a `Py5Image object`.
+
 Underlying Processing method: [PImage.copy](https://processing.org/reference/PImage_copy_.html)
 
 ## Signatures

--- a/reference/sketch_copy.md
+++ b/reference/sketch_copy.md
@@ -33,6 +33,8 @@ Copies a region of pixels from the display window to another area of the display
 
 This function ignores [](sketch_image_mode).
 
+If you want to create a new image with the contents of a rectangular region of the screen, check out [`get_pixels(x, y, w, h)`](sketch_get_pixels) where x, y, w, h, are the position and dimensions of the area to be copied. It will return a `Py5Image` object.
+
 Underlying Processing method: [copy](https://processing.org/reference/copy_.html)
 
 ## Signatures


### PR DESCRIPTION
This is a PR attempt based on our discussion here: https://github.com/py5coding/py5generator/discussions/624
I hope it helps someone reading the docs... I'm not sure anymore...

I'm unsure about some stylistic details (such as adding a dot to the references of method names...) and about the magical links that *pybook* likes (no `/reference/` at the path to the linked pages, or should I add them?).

This is not very urgent stuff... :) 

